### PR TITLE
Added beforeCreate callback to allow for modification of user data

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ app.use(function (err, req, res, next) {
 });
 ```
 
+## Alter user data before creating a new user
+
+Register a `beforeCreate` callback in options and modify/enrich the passed in user object with profile data contained in the jwt token:
+
+```js
+var auth = require('loopback-jwt')(app,{
+    secretKey: '<secret>',
+    model: '<model>',
+    beforeCreate: function(newUser, data) {
+      newUser.name = data.name;
+    }
+});
+```
+
+
 ## Contributors
 
  https://github.com/whoGloo/loopback-jwt/graphs/contributors

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,10 +40,17 @@ module.exports = function(app,options) {
 
     var checkJwt = jwt({
         algorithms: data.algorithms,
-        secret: data.secretKey
+        secret: data.secretKey,
+        credentialsRequired: options.credentialsRequired
     });
 
     var mapUser = function(req,res,next) {
+        if (!req.user) {
+            debug("no current user context found.");
+            next();
+            return;
+        }
+
         debug("attempting to map user [%s]",req.user[data.identifier]);
 
         var id = req.user[data.identifier];

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,11 +111,16 @@ module.exports = function(app,options) {
         var id = req.user[data.identifier];
 
         return new Promise(function(resolve,reject) {
-
-            app.models[data.model].create({
+            newUserData = {
                 email: id,
                 password: data.password
-            })
+            }
+
+            if (typeof options.beforeCreate === 'function') {
+                options.beforeCreate(newUserData, req.user);
+            }
+
+            app.models[data.model].create(newUserData)
 
             .then(function(newUser) {
                 debug("new user created [%s]",newUser.email);


### PR DESCRIPTION
I'm using `loopback-jwt` to integrate [auth0.com](https://auth0.com/) with an existing lb application. What I needed was a way to modify the data of a new user with profile data stored in the jwt before it gets saved to the database.

I've attempted to do this in a `before save` hook for the user model, but unfortunately it's not possible to access `req.user` in an operation hook. Hence the only way I saw to make this work was to add this custom callback with the required jwt data passed in as argument.