### PR TITLE
Fixed loss of loopback context.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@
 module.exports = function(app,options) {
     var debug = require('debug')('loopback-jwt');
     var jwt = require('express-jwt');
+    var Promise = require("bluebird");
 
     var userMap = {};
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,8 @@ module.exports = function(app,options) {
     var checkJwt = jwt({
         algorithms: data.algorithms,
         secret: data.secretKey,
-        credentialsRequired: options.credentialsRequired
+        credentialsRequired: options.credentialsRequired,
+        getToken: options.getToken
     });
 
     var mapUser = function(req,res,next) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/whoGloo/loopback-jwt#readme",
   "dependencies": {
+    "bluebird": "^3.3.4",
     "debug": "^2.2.0",
     "express-jwt": "^3.3.0",
     "uuid": "^2.0.1"


### PR DESCRIPTION
Loopback is known to have issues with [loosing the context when using native Promises](https://github.com/strongloop/loopback/issues/878#issuecomment-173441560). I ran into this same issue and fixed it by replacing native with bluebird 'Promise'. 