### PR TITLE
if the create user errors out, invoke the callback passing along the …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,6 +78,7 @@ module.exports = function(app,options) {
 
                 .catch(function(e) {
                     debug("ERR",e);
+                    next(e);
                 });
 
             });


### PR DESCRIPTION
…error. without this, there's no way to respond to errors and requests may hang

There are cases when the create would fail (e.g. database is unavailable, etc.), however in my case I also wanted to be able to throw an Error() in the beforeCreate() when an email address wasn't passed along in the JWT and cleanly bail.

I was just seeing hangs when the user create bailed.