### PR TITLE
allow beforeCreate to return a promise

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ module.exports = function(app,options) {
         credentialsRequired: options.credentialsRequired,
         getToken: options.getToken
     })
-    
+
     .unless( { path: options.unless || []} );
 
     var mapUser = function(req,res,next) {
@@ -129,24 +129,33 @@ module.exports = function(app,options) {
             }
 
             if (typeof options.beforeCreate === 'function') {
-                options.beforeCreate(newUserData, req.user);
+                resolve(options.beforeCreate(newUserData,req.user));
+            } else {
+                resolve(newUserData);
             }
+        })
 
+        .then(function(newUserData) {
             app.models[data.model].create(newUserData)
 
             .then(function(newUser) {
                 debug("new user created [%s]",newUser.email);
                 loginUser(req)
 
-                .then(function() {
-                    resolve();
+                .then(function () {
+                    Promise.resolve();
                 });
             })
 
             .catch(function(e) {
-                debug("error creating user",e);
-                reject(e);
-            });
+              debug("error creating user",e);
+              Promise.reject(e);
+            })
+        })
+
+        .catch(function(e) {
+            debug("error creating user",e);
+            Promise.reject(e);
         });
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -129,7 +129,9 @@ module.exports = function(app,options) {
             }
 
             if (typeof options.beforeCreate === 'function') {
-                resolve(options.beforeCreate(newUserData,req.user));
+                resolve(
+                  options.beforeCreate(newUserData,req.user) || newUserData
+                );
             } else {
                 resolve(newUserData);
             }


### PR DESCRIPTION
In my scenario I need to make a get request to a remote api to fetch some extra data, this change allows user to return a Promise from beforeCreate callback in case some async work is needed. This may be my very specific case but maybe it can be used by others. Only difference is that beforeCreate must now return a value instead of just modifying data in newUser parameter.