### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![NPM Version][npm-image]][npm-url]
 [![NPM Downloads][downloads-image]][downloads-url]
-[![Build Status][travis-image]][travis-url]
-[![Test Coverage][coveralls-image]][coveralls-url]
 [![Gratipay][gratipay-image]][gratipay-url]
 
   loopback-jwt is a node express middleware plugin to map [Json Web tokens](https://www.jwt.io) and [Loopback](https://strongloop.com/) users.
@@ -102,10 +100,6 @@ var auth = require('loopback-jwt')(app,{
 
 [npm-image]: https://img.shields.io/npm/v/loopback-jwt.svg
 [npm-url]: https://npmjs.org/package/loopback-jwt
-[travis-image]: https://img.shields.io/travis/whoGloo/loopback-jwt/master.svg
-[travis-url]: https://travis-ci.org/whoGloo/loopback-jwt
-[coveralls-image]: https://img.shields.io/coveralls/whoGloo/loopback-jwt/master.svg
-[coveralls-url]: https://coveralls.io/r/whoGloo/loopback-jwt
 [downloads-image]: https://img.shields.io/npm/dm/loopback-jwt.svg
 [downloads-url]: https://npmjs.org/package/loopback-jwt
 [gratipay-image]: https://img.shields.io/gratipay/dougwilson.svg

--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ var auth = require('loopback-jwt')(app,{
 
 [MIT](LICENSE)
 
-[npm-image]: https://img.shields.io/npm/v/connect.svg
-[npm-url]: https://npmjs.org/package/connect
-[travis-image]: https://img.shields.io/travis/senchalabs/connect/master.svg
-[travis-url]: https://travis-ci.org/senchalabs/connect
-[coveralls-image]: https://img.shields.io/coveralls/senchalabs/connect/master.svg
-[coveralls-url]: https://coveralls.io/r/senchalabs/connect
-[downloads-image]: https://img.shields.io/npm/dm/connect.svg
-[downloads-url]: https://npmjs.org/package/connect
+[npm-image]: https://img.shields.io/npm/v/loopback-jwt.svg
+[npm-url]: https://npmjs.org/package/loopback-jwt
+[travis-image]: https://img.shields.io/travis/whoGloo/loopback-jwt/master.svg
+[travis-url]: https://travis-ci.org/whoGloo/loopback-jwt
+[coveralls-image]: https://img.shields.io/coveralls/whoGloo/loopback-jwt/master.svg
+[coveralls-url]: https://coveralls.io/r/whoGloo/loopback-jwt
+[downloads-image]: https://img.shields.io/npm/dm/loopback-jwt.svg
+[downloads-url]: https://npmjs.org/package/loopback-jwt
 [gratipay-image]: https://img.shields.io/gratipay/dougwilson.svg
 [gratipay-url]: https://www.gratipay.com/dougwilson/


### PR DESCRIPTION
It looks like your badges were mistakenly copied from senchalabs/connect. I've corrected the relevant URLs and removed travis and coveralls badges, which don't appear to be used.